### PR TITLE
인증메일 재전송시 메일수신자 이름이 기재되지 않는 버그

### DIFF
--- a/modules/member/member.controller.php
+++ b/modules/member/member.controller.php
@@ -1264,7 +1264,7 @@ class memberController extends member
 		$oMail->setTitle( Context::getLang('msg_confirm_account_title') );
 		$oMail->setContent($content);
 		$oMail->setSender( $member_config->webmaster_name?$member_config->webmaster_name:'webmaster', $member_config->webmaster_email);
-		$oMail->setReceiptor( $args->email_address, $args->email_address );
+		$oMail->setReceiptor( $member_info->user_name, $member_info->email_address );
 		$oMail->send();
 
 		$msg = sprintf(Context::getLang('msg_confirm_mail_sent'), $args->email_address);


### PR DESCRIPTION
refer to https://github.com/xpressengine/xe-core/pull/960